### PR TITLE
Fix/stack logo wrap

### DIFF
--- a/app/Logo.tsx
+++ b/app/Logo.tsx
@@ -2,7 +2,7 @@ import Image, { ImageProps } from "next/image";
 
 export default function Logo({ title, ...props }: ImageProps) {
   return (
-    <div className="flex flex-col items-center pb-8 pr-6">
+    <div className="flex flex-col items-center">
       <Image className="h-12 w-12" {...props} alt={"" || props.alt} />
       <p className="pt-3 text-center text-sm font-normal">{title}</p>
     </div>

--- a/app/StackGroup.tsx
+++ b/app/StackGroup.tsx
@@ -11,7 +11,9 @@ export default function StackGroup({ title, children }: StackGroupProps) {
       <h4 className="pb-4 font-serif text-sm font-bold uppercase text-violet-300">
         {title}
       </h4>
-      <div className="flex flex-wrap items-start">{children}</div>
+      <div className="flex flex-wrap items-start [&>*]:pr-6 [&>*]:pb-8">
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description
Fix an **overflowing** issue in the `Stack` block.

When there were too many logos to fit on a single line, it overflowed the screen width and broke the layout
See below on a `320px` wide screen:

<img width="479" alt="Screenshot 2023-01-06 at 10 34 43" src="https://user-images.githubusercontent.com/12157019/210973312-8fb029d1-cd4e-4e42-993c-585823db61cd.png">


## Changes
* add a [`flex-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap) in the `<StackGroup />`, the parent component of the `<Logo />` so long lines wrap.
* use [_arbitrary values selectors_](https://tailwindcss.com/blog/tailwindcss-v3-1#arbitrary-values-but-for-variants) [allowed](https://stackoverflow.com/a/72683383/5186918) by _Tailwind_ to apply more specific spacing between logos
  * using `space-x-6` for instance applied a _left_ margin which broke alignment on the second row when wrapping
  * when wrapping we need to apply a bottom padding between logos (so there is space between the rows), not only on the `StackGroup`

## After the change
- Before: https://website-jhw7yghxt-qraft.vercel.app/
- After: https://website-1xm1cjc0t-qraft.vercel.app/

<img width="492" alt="Screenshot 2023-01-06 at 10 43 20" src="https://user-images.githubusercontent.com/12157019/210974793-2d0052df-e745-4b0a-a3eb-287d1410fcd8.png">

