### PR TITLE
chore(ci): add `merge_group` to GitHub Actions `lint` workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
Closes #28 

Trigger `lint` on [`merge_group` events](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)