### PR TITLE
Remove `agency` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Lint](https://github.com/qrafttech/website/actions/workflows/lint.yml/badge.svg)](https://github.com/qrafttech/website/actions/workflows/lint.yml)
 
-Website for the **Qraft** software engineering agency; powered by [_Next.js_](https://nextjs.org/) and [_Tailwind CSS_](https://tailwindcss.com/).
+Website for the **Qraft** software engineering company; powered by [_Next.js_](https://nextjs.org/) and [_Tailwind CSS_](https://tailwindcss.com/).
 
 ## Installation
 


### PR DESCRIPTION
# Description
All `agency/agence` wording was removed in #33, but obviously the `README` was forgotten 🙈

Remove what I hope is the last instance of this wording