### PR TITLE
feat: replace mailto CTA with Cal.com booking and add bottom CTA

### DIFF
--- a/app/components/CallToAction.tsx
+++ b/app/components/CallToAction.tsx
@@ -1,0 +1,26 @@
+import SectionTitle from "./SectionTitle";
+
+export default function CallToAction() {
+  return (
+    <div className="flex flex-col items-center gap-8 py-20 text-center">
+      <SectionTitle className="from-white to-white/70">
+        On en discute ?
+      </SectionTitle>
+      <p className="max-w-lg text-lg text-white/80">
+        Reservez un creneau de 30 minutes pour parler de votre projet.
+      </p>
+      <a
+        href="https://cal.com/nicolasrouanne/30min"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <button
+          type="button"
+          className="rounded-2xl border border-white bg-transparent px-8 py-3 font-medium text-white hover:bg-white/20"
+        >
+          Prendre rendez-vous
+        </button>
+      </a>
+    </div>
+  );
+}

--- a/app/components/ContactUs.tsx
+++ b/app/components/ContactUs.tsx
@@ -3,12 +3,9 @@ import clsx from "clsx";
 type ContactUsProps = Partial<Pick<HTMLDivElement, "className">>;
 
 export default function ContactUs({ className }: ContactUsProps) {
-  const email = "hello@qraft.tech";
-  const subject = "Hello Qraft - Un petit mail après être allé sur votre site";
-
   return (
     <a
-      href={`mailto:${email}?subject=${subject}`}
+      href="https://cal.com/nicolasrouanne/30min"
       target="_blank"
       rel="noreferrer"
     >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import FluidContainer from "../components/FluidContainer";
 import Team from "./components/Team";
 import Menu from "./components/Menu.client";
 import Portfolio from "./components/Portfolio";
+import CallToAction from "./components/CallToAction";
 
 export default function Home() {
   return (
@@ -54,6 +55,9 @@ export default function Home() {
         <div className="pt-16">
           <Portfolio />
         </div>
+      </FluidContainer>
+      <FluidContainer className="bg-gradient-to-r from-[#2B0AB1] via-[#324DB1] to-[#4AA7B8]">
+        <CallToAction />
       </FluidContainer>
     </main>
   );


### PR DESCRIPTION
## Why

The "Nous contacter" button currently opens a mailto link, which adds friction to the contact flow. Replacing it with a Cal.com booking link lets prospects schedule a call directly. Adding a bottom CTA after the Portfolio section gives visitors a clear next step once they've reviewed the site content.

## What

- Swap the mailto link for a Cal.com 30-min booking link across the site
- Add a new "On en discute ?" call-to-action section at the bottom of the page with matching gradient styling

## Changes

- **`app/components/ContactUs.tsx`** - Replace `mailto:` href with Cal.com link, remove unused `email`/`subject` variables
- **`app/components/CallToAction.tsx`** (new) - Bottom CTA with heading, subtext, and booking button
- **`app/page.tsx`** - Add `CallToAction` section in a gradient `FluidContainer` after Portfolio