### PR TITLE
fix: prevent horizontal overflow in FluidContainer on mobile

### DIFF
--- a/components/FluidContainer.tsx
+++ b/components/FluidContainer.tsx
@@ -12,7 +12,7 @@ export default function FluidContainer({
 }: FluidContainerProps) {
   return (
     <div id={id} className={clsx("flex justify-center", className)}>
-      <div className="max-w-screen-2xl px-4 pt-6 lg:px-24 xl:px-32">
+      <div className="w-full max-w-screen-2xl px-4 pt-6 lg:px-24 xl:px-32">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- `FluidContainer`'s inner div lacked `w-full`. Inside `flex justify-center`, that made its width follow content width — so any child with an unbreakable long string (e.g. a Notion `<pre>` code line in a blog article) expanded the container past the viewport, causing horizontal scroll on mobile.
- Adding `w-full` constrains the inner div to its parent's width; `max-w-screen-2xl` still caps it on desktop. The `<pre>`'s existing `overflow-x-auto` then scrolls internally instead of pushing the page.

Verified live at 390×844 (iPhone): `document.scrollWidth === window.innerWidth`, title wraps, `<pre>` scrolls in-place. No visual change on the home page where content already filled the width.

## Test plan
- [ ] Open `/blog` on mobile width (~390px) — no horizontal scroll
- [ ] Open a blog article with code blocks on mobile — title wraps, code blocks scroll internally
- [ ] Sanity check the home page on mobile + desktop — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)