### PR TITLE
fix: proxy Notion images to avoid expired S3 URLs

### DIFF
--- a/app/api/notion-image/route.ts
+++ b/app/api/notion-image/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { notion } from "../../../lib/notion";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const CACHE_HEADER =
+  "public, s-maxage=86400, stale-while-revalidate=604800, max-age=3600";
+
+export async function GET(request: NextRequest) {
+  const blockId = request.nextUrl.searchParams.get("blockId");
+
+  if (!blockId || !UUID_RE.test(blockId)) {
+    return NextResponse.json({ error: "Invalid blockId" }, { status: 400 });
+  }
+
+  let block;
+  try {
+    block = await notion.blocks.retrieve({ block_id: blockId });
+  } catch {
+    return NextResponse.json({ error: "Block not found" }, { status: 404 });
+  }
+
+  if (
+    !("type" in block) ||
+    block.type !== "image" ||
+    block.image.type !== "file"
+  ) {
+    return NextResponse.json(
+      { error: "Block is not a Notion-hosted image" },
+      { status: 404 }
+    );
+  }
+
+  const upstream = await fetch(block.image.file.url);
+  if (!upstream.ok || !upstream.body) {
+    return NextResponse.json(
+      { error: "Upstream fetch failed" },
+      { status: 502 }
+    );
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "Content-Type": upstream.headers.get("Content-Type") ?? "image/*",
+      "Cache-Control": CACHE_HEADER,
+    },
+  });
+}

--- a/app/components/NotionRenderer.tsx
+++ b/app/components/NotionRenderer.tsx
@@ -173,7 +173,7 @@ function BlockRenderer({ block }: { block: NotionBlock }) {
     case "image": {
       const imgUrl =
         block.image.type === "file"
-          ? block.image.file.url
+          ? `/api/notion-image?blockId=${block.id}`
           : block.image.external.url;
       return (
         <figure>

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -6,7 +6,7 @@ import type {
   RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints";
 
-const notion = new Client({
+export const notion = new Client({
   auth: process.env.NOTION_API_KEY,
   retry: { maxRetries: 3 },
 });
@@ -16,8 +16,6 @@ function requireEnv(name: string): string {
   if (!value) throw new Error(`${name} environment variable is required`);
   return value;
 }
-
-const databaseId = requireEnv("NOTION_DATABASE_ID");
 
 const PROP_LANGUAGE = "Language";
 const PROP_DATE = "Date";
@@ -144,7 +142,7 @@ export async function fetchArticles(): Promise<ArticleMeta[]> {
 
   try {
     const response = await notion.dataSources.query({
-      data_source_id: databaseId,
+      data_source_id: requireEnv("NOTION_DATABASE_ID"),
       filter: {
         property: PROP_LANGUAGE,
         select: { equals: "FR" },


### PR DESCRIPTION
## Summary

- Nouvelle route `app/api/notion-image/route.ts` qui résout une URL S3 fraîche via `notion.blocks.retrieve({ block_id })` et stream le binaire avec `Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800`.
- `NotionRenderer` pointe les images Notion-hosted (type `file`) sur cette route au lieu de l'URL S3 signée. Les images `external` (Unsplash, etc.) restent directes.
- `lib/notion.ts` : `notion` client exporté pour réutilisation ; `databaseId` rendu lazy pour ne plus crasher au load du module dans la route.

## Pourquoi

Les URLs S3 signées de Notion expirent au bout d'1h (`X-Amz-Expires=3600`). Après expiration, S3 répond 403 + `Content-Type: application/xml` → Chrome bloque (ORB/CORB). Avec `cacheLife("max")` sur `fetchArticleById`, l'URL morte est gelée et servie à tous les visiteurs (cf. https://qraft.tech/blog/350218ed-56d7-814c-88a2-def1a2800fd2). Aucun CDN ne peut intervenir parce que le domaine S3 est externe.

En proxifiant via `qraft.tech`, l'URL devient stable → Cloudflare + Vercel cachent l'image à l'edge ; un seul appel Notion API par image par jour au pire.

Closes #71

## Test plan

- [ ] Vérifier que les images du blog s'affichent après merge sur l'article cassé
- [ ] Vérifier qu'une image `external` (si présente dans un article) charge toujours
- [ ] `cf-cache-status` au 2ème hit de `/api/notion-image?blockId=…` (sera DYNAMIC tant qu'aucune Cache Rule Cloudflare n'est ajoutée — pas bloquant, le cache Vercel s'occupe déjà du gros)
- [ ] `?blockId=foo` → 400, `?blockId=<UUID inexistant>` → 404
- [ ] (Optionnel) Ajouter la Cache Rule Cloudflare pour `/api/notion-image*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
